### PR TITLE
Add Random Song Option (Adds #49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Support for [HACS](https://github.com/custom-components/hacs).
 **New in 1.20**
 - Add support for dailyMixes using spotcast 2.6.0
 
+**New In 1.21**
+- Add option to start playlists from random song.
 
 ![Screenshot](/spotify-card-highlight.png)
 
@@ -83,6 +85,7 @@ Now add the card like this:
       player: <optional use this player only, value should be the same name as the displayname of the player>
       featuredPlaylists: <optional show featured playlists instead of users playlists>
       height: <optional pixels height for the playlist element. If content is larger scrolling will be enabled>
+      random_song: <optional boolean to start playlists from a random song>
 ```
 
 If you add the `device` setting, the card will select it by default and will not display the dropdown menu.

--- a/src/SpotifyCard.js
+++ b/src/SpotifyCard.js
@@ -204,6 +204,7 @@ export default class SpotifyCard extends Component {
       device_name: device,
       uri: playlist.uri,
       force_playback: this.state.currentPlayer != null,
+      random_song: (this.props.random_song?this.props.random_song : false),
     };
 
     if (this.props.account) {


### PR DESCRIPTION
Adds lovelace option to shuffle songs or not. Not able to produce dist files for (not sure how) but this setup works with a 'true' edited in my personal home environment, and should work since it just adds another boolean field.