### PR TITLE
Add Playlist Shuffle

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Now add the card like this:
       featuredPlaylists: <optional show featured playlists instead of users playlists>
       dailyMixes: <optional show daily mixes, requires spotcast>
       height: <optional pixels height for the playlist element. If content is larger scrolling will be enabled>
-      random_song: <optional boolean to start playlists from a random song>
+      random_song: <optional boolean to start playlists from a random song (only through Spotcast devices)>
+      shuffle: <optional boolean to shuffle playlist on play>
 ```
 
 If you add the `device` setting, the card will select it by default and will not display the dropdown menu.

--- a/src/SpotifyCard.js
+++ b/src/SpotifyCard.js
@@ -163,6 +163,14 @@ export default class SpotifyCard extends Component {
       console.error('Will not play because there is no playlist or device selected,', selectedPlaylist, selectedDevice);
       return;
     }
+    fetch('https://api.spotify.com/v1/me/player/shuffle?state=' + (this.props.shuffle?this.props.shuffle : false), {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${localStorage.getItem(this.getLocalStorageTokenName())}`,
+      },
+      body: JSON.stringify({ device_id: selectedDevice.id }),
+    });
     fetch('https://api.spotify.com/v1/me/player/play?device_id=' + selectedDevice.id, {
       method: 'PUT',
       headers: {
@@ -205,6 +213,7 @@ export default class SpotifyCard extends Component {
       uri: playlist.uri,
       force_playback: this.state.currentPlayer != null,
       random_song: (this.props.random_song?this.props.random_song : false),
+      shuffle: (this.props.shuffle?this.props.shuffle : false),
     };
 
     if (this.props.account) {


### PR DESCRIPTION
Adds separate shuffle option to choose random songs within playlist. With this option, playlist will still start at first song, then shuffle. In tandem with random_song allows for full shuffling.