### PR TITLE
Update README version url

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Follow the HACS instructions when installing it.
 ```
   - type: module
     url: >-
-      https://cdn.jsdelivr.net/gh/custom-cards/spotify-card@1.8/dist/spotify-card.umd.js
+      https://cdn.jsdelivr.net/gh/custom-cards/spotify-card@1.25.0/dist/spotify-card.umd.js
 ```
 
 ##### Add the card to lovelace config


### PR DESCRIPTION
I was having trouble getting this working, until I realized the CDN version URL in the README is out if date. This brings it back up to 1.25.0