### PR TITLE
Adds delayed cover loading

### DIFF
--- a/src/spotify-card.ts
+++ b/src/spotify-card.ts
@@ -76,10 +76,10 @@ export class SpotifyCard extends LitElement {
     this.lib.connectedCallback();
   }
 
-  protected async updated(changedProps: PropertyValues): Promise<void> {
+  protected updated(changedProps: PropertyValues): void {
     super.updated(changedProps);
     this.lib.updated(this.hass);
-    await this.updateComplete.then(() => {
+    this.updateComplete.then(() => {
       for (const cover of this.renderRoot.querySelectorAll('[data-spotify-image-url]') as NodeListOf<HTMLDivElement>) {
         const downloadingImage = new Image();
         downloadingImage.onload = function (event) {

--- a/src/spotify-card.ts
+++ b/src/spotify-card.ts
@@ -236,7 +236,7 @@ export class SpotifyCard extends LitElement {
       result.push(html`<div class="list-item" @click=${(elem) => this.lib.playUri(elem, item.uri)}>
         <div
           class="cover"
-          data-spotify-image-url="${item.images.length > 0 ? item.images[item.images.length - 1].url : ''}"
+          data-spotify-image-url="${item.images.length > 0 ? item.images[0].url : ''}"
         >
           <svg viewBox="0 0 168 168">
             <path
@@ -281,7 +281,7 @@ export class SpotifyCard extends LitElement {
       result.push(html`<div class="grid-item" @click=${(elem) => this.lib.playUri(elem, item.uri)}>
         <div
           class="grid-item-album-image ${this.lib.isThisPlaylistPlaying(item) ? 'playing' : ''}"
-          data-spotify-image-url="${item.images.length > 0 ? item.images[item.images.length - 1].url : ''}"
+          data-spotify-image-url="${item.images.length > 0 ? item.images[0].url : ''}"
         >
           <svg viewBox="0 0 168 168">
             <path

--- a/src/spotify-card.ts
+++ b/src/spotify-card.ts
@@ -76,9 +76,18 @@ export class SpotifyCard extends LitElement {
     this.lib.connectedCallback();
   }
 
-  protected updated(changedProps: PropertyValues): void {
+  protected async updated(changedProps: PropertyValues): Promise<void> {
     super.updated(changedProps);
     this.lib.updated(this.hass);
+    await this.updateComplete.then(() => {
+      for (const cover of this.renderRoot.querySelectorAll('[data-spotify-image-url]') as NodeListOf<HTMLDivElement>) {
+        const downloadingImage = new Image();
+        downloadingImage.onload = function (event) {
+          cover.firstElementChild?.replaceWith(event.srcElement as HTMLDivElement);
+        };
+        cover.dataset.spotifyImageUrl ? (downloadingImage.src = cover.dataset.spotifyImageUrl) : '';
+      }
+    });
   }
 
   public disconnectedCallback(): void {
@@ -225,13 +234,16 @@ export class SpotifyCard extends LitElement {
     for (let i = 0; i < playlists.length; i++) {
       const item = playlists[i];
       result.push(html`<div class="list-item" @click=${(elem) => this.lib.playUri(elem, item.uri)}>
-        ${item.images.length > 0
-          ? html`<img src=${item.images[item.images.length - 1].url} />`
-          : html`<svg viewBox="0 0 168 168">
-              <path
-                d="M 83.996 0.277 C 37.747 0.277 0.253 37.77 0.253 84.019 C 0.253 130.27 37.747 167.76 83.996 167.76 C 130.25 167.76 167.74 130.27 167.74 84.019 C 167.74 37.773 130.25 0.281 83.995 0.281 L 83.996 0.277 L 83.996 0.277 Z M 122.4 121.057 C 120.9 123.517 117.68 124.297 115.22 122.787 C 95.558 110.777 70.806 108.057 41.656 114.717 C 38.847 115.357 36.047 113.597 35.407 110.787 C 34.764 107.977 36.517 105.177 39.333 104.537 C 71.233 97.249 98.596 100.387 120.67 113.877 C 123.13 115.387 123.91 118.597 122.4 121.057 L 122.4 121.057 Z M 132.65 98.255 C 130.76 101.327 126.74 102.297 123.67 100.407 C 101.16 86.571 66.847 82.564 40.222 90.646 C 36.769 91.689 33.122 89.743 32.074 86.296 C 31.034 82.843 32.981 79.203 36.428 78.153 C 66.841 68.925 104.65 73.395 130.5 89.28 C 133.57 91.17 134.54 95.19 132.65 98.256 L 132.65 98.255 Z M 133.53 74.511 C 106.54 58.48 62.01 57.006 36.241 64.827 C 32.103 66.082 27.727 63.746 26.473 59.608 C 25.219 55.468 27.553 51.095 31.694 49.837 C 61.275 40.857 110.45 42.592 141.524 61.039 C 145.254 63.248 146.474 68.055 144.264 71.772 C 142.064 75.494 137.244 76.721 133.534 74.511 L 133.53 74.511 Z"
-              />
-            </svg>`}
+        <div
+          class="cover"
+          data-spotify-image-url="${item.images.length > 0 ? item.images[item.images.length - 1].url : ''}"
+        >
+          <svg viewBox="0 0 168 168">
+            <path
+              d="M 83.996 0.277 C 37.747 0.277 0.253 37.77 0.253 84.019 C 0.253 130.27 37.747 167.76 83.996 167.76 C 130.25 167.76 167.74 130.27 167.74 84.019 C 167.74 37.773 130.25 0.281 83.995 0.281 L 83.996 0.277 L 83.996 0.277 Z M 122.4 121.057 C 120.9 123.517 117.68 124.297 115.22 122.787 C 95.558 110.777 70.806 108.057 41.656 114.717 C 38.847 115.357 36.047 113.597 35.407 110.787 C 34.764 107.977 36.517 105.177 39.333 104.537 C 71.233 97.249 98.596 100.387 120.67 113.877 C 123.13 115.387 123.91 118.597 122.4 121.057 L 122.4 121.057 Z M 132.65 98.255 C 130.76 101.327 126.74 102.297 123.67 100.407 C 101.16 86.571 66.847 82.564 40.222 90.646 C 36.769 91.689 33.122 89.743 32.074 86.296 C 31.034 82.843 32.981 79.203 36.428 78.153 C 66.841 68.925 104.65 73.395 130.5 89.28 C 133.57 91.17 134.54 95.19 132.65 98.256 L 132.65 98.255 Z M 133.53 74.511 C 106.54 58.48 62.01 57.006 36.241 64.827 C 32.103 66.082 27.727 63.746 26.473 59.608 C 25.219 55.468 27.553 51.095 31.694 49.837 C 61.275 40.857 110.45 42.592 141.524 61.039 C 145.254 63.248 146.474 68.055 144.264 71.772 C 142.064 75.494 137.244 76.721 133.534 74.511 L 133.53 74.511 Z"
+            />
+          </svg>
+        </div>
         ${this.lib.isThisPlaylistPlaying(item)
           ? this.generateButtonForCurrent()
           : html`<div class="icon">
@@ -267,18 +279,16 @@ export class SpotifyCard extends LitElement {
       const item = playlists[i];
       this.lib.spotify_state?.attributes.media_playlist === item.name;
       result.push(html`<div class="grid-item" @click=${(elem) => this.lib.playUri(elem, item.uri)}>
-        ${item.images.length > 0
-          ? html`<img
-              class="grid-item-album-image ${this.lib.isThisPlaylistPlaying(item) ? 'playing' : ''}"
-              src=${item.images[item.images.length - 1].url}
-            />`
-          : html`<div class="grid-item-album-image ${this.lib.isThisPlaylistPlaying(item) ? 'playing' : ''}">
-              <svg viewBox="0 0 168 168">
-                <path
-                  d="M 83.996 0.277 C 37.747 0.277 0.253 37.77 0.253 84.019 C 0.253 130.27 37.747 167.76 83.996 167.76 C 130.25 167.76 167.74 130.27 167.74 84.019 C 167.74 37.773 130.25 0.281 83.995 0.281 L 83.996 0.277 L 83.996 0.277 Z M 122.4 121.057 C 120.9 123.517 117.68 124.297 115.22 122.787 C 95.558 110.777 70.806 108.057 41.656 114.717 C 38.847 115.357 36.047 113.597 35.407 110.787 C 34.764 107.977 36.517 105.177 39.333 104.537 C 71.233 97.249 98.596 100.387 120.67 113.877 C 123.13 115.387 123.91 118.597 122.4 121.057 L 122.4 121.057 Z M 132.65 98.255 C 130.76 101.327 126.74 102.297 123.67 100.407 C 101.16 86.571 66.847 82.564 40.222 90.646 C 36.769 91.689 33.122 89.743 32.074 86.296 C 31.034 82.843 32.981 79.203 36.428 78.153 C 66.841 68.925 104.65 73.395 130.5 89.28 C 133.57 91.17 134.54 95.19 132.65 98.256 L 132.65 98.255 Z M 133.53 74.511 C 106.54 58.48 62.01 57.006 36.241 64.827 C 32.103 66.082 27.727 63.746 26.473 59.608 C 25.219 55.468 27.553 51.095 31.694 49.837 C 61.275 40.857 110.45 42.592 141.524 61.039 C 145.254 63.248 146.474 68.055 144.264 71.772 C 142.064 75.494 137.244 76.721 133.534 74.511 L 133.53 74.511 Z"
-                />
-              </svg>
-            </div>`}
+        <div
+          class="grid-item-album-image ${this.lib.isThisPlaylistPlaying(item) ? 'playing' : ''}"
+          data-spotify-image-url="${item.images.length > 0 ? item.images[item.images.length - 1].url : ''}"
+        >
+          <svg viewBox="0 0 168 168">
+            <path
+              d="M 83.996 0.277 C 37.747 0.277 0.253 37.77 0.253 84.019 C 0.253 130.27 37.747 167.76 83.996 167.76 C 130.25 167.76 167.74 130.27 167.74 84.019 C 167.74 37.773 130.25 0.281 83.995 0.281 L 83.996 0.277 L 83.996 0.277 Z M 122.4 121.057 C 120.9 123.517 117.68 124.297 115.22 122.787 C 95.558 110.777 70.806 108.057 41.656 114.717 C 38.847 115.357 36.047 113.597 35.407 110.787 C 34.764 107.977 36.517 105.177 39.333 104.537 C 71.233 97.249 98.596 100.387 120.67 113.877 C 123.13 115.387 123.91 118.597 122.4 121.057 L 122.4 121.057 Z M 132.65 98.255 C 130.76 101.327 126.74 102.297 123.67 100.407 C 101.16 86.571 66.847 82.564 40.222 90.646 C 36.769 91.689 33.122 89.743 32.074 86.296 C 31.034 82.843 32.981 79.203 36.428 78.153 C 66.841 68.925 104.65 73.395 130.5 89.28 C 133.57 91.17 134.54 95.19 132.65 98.256 L 132.65 98.255 Z M 133.53 74.511 C 106.54 58.48 62.01 57.006 36.241 64.827 C 32.103 66.082 27.727 63.746 26.473 59.608 C 25.219 55.468 27.553 51.095 31.694 49.837 C 61.275 40.857 110.45 42.592 141.524 61.039 C 145.254 63.248 146.474 68.055 144.264 71.772 C 142.064 75.494 137.244 76.721 133.534 74.511 L 133.53 74.511 Z"
+            />
+          </svg>
+        </div>
         <div class="grid-item-overlay-icon">
           ${this.lib.isThisPlaylistPlaying(item)
             ? this.generateGridIconForCurrent()
@@ -505,15 +515,21 @@ export class SpotifyCard extends LitElement {
       border-bottom: 0;
     }
 
-    .list-item > img,
-    .list-item > svg {
+    .cover {
+    }
+
+    .list-item .cover {
       height: var(--list-item-height);
       object-fit: contain;
     }
 
-    .list-item > svg {
+    .cover > img {
+      height: 100%;
+    }
+
+    .cover > svg {
       height: calc(var(--list-item-height) - var(--placeholder-padding));
-      margin-right: var(--placeholder-padding);
+      margin: calc(var(--placeholder-padding) / 2);
     }
 
     .list-item > .icon {
@@ -537,21 +553,26 @@ export class SpotifyCard extends LitElement {
     .grid {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(30%, 1fr));
-      grid-gap: 5px;
+      grid-gap: 0.5em;
     }
 
     .grid-item {
       position: relative;
       cursor: pointer;
+      box-shadow: var(--primary-text-color) 0 0 0.2em;
     }
 
     .grid-item-album-image {
       width: 100%;
-      height: auto;
-      box-shadow: var(--primary-text-color) 0 0 0.2em;
+      display: flex;
+    }
+
+    .grid-item-album-image > img {
+      width: 100%;
     }
 
     .grid-item-album-image > svg {
+      width: 100%;
       margin: 10px;
       fill: var(--primary-text-color);
     }


### PR DESCRIPTION
This modification changes the way the covers are loaded. First a placeholder image is displayed and when the page is done with loading, the placeholder images are relaced by the high resolution cover images.

What do you think of this? This would be nice for slow loading connections, as right now it blocks displaying until all covers are completly loaded.