### PR TITLE
Misc. CSS changes

### DIFF
--- a/src/spotify-card.ts
+++ b/src/spotify-card.ts
@@ -668,10 +668,6 @@ export class SpotifyCard extends LitElement {
       border-radius: 50%;
     }
 
-    .mediaplayer_speaker_icon > path {
-      fill: var(--primary-text-color);
-    }
-
     .dropdown-wrapper {
       display: contents;
       position: absolute;
@@ -715,12 +711,12 @@ export class SpotifyCard extends LitElement {
       display: block;
     }
 
-    .icon > svg {
+    svg {
       fill: var(--primary-text-color);
     }
 
     .icon.playing > svg {
-      fill: var(--primary-color) !important;
+      fill: var(--primary-color);
     }
 
     @keyframes loading {
@@ -825,7 +821,6 @@ export class SpotifyCard extends LitElement {
     .grid-item-album-image > svg {
       width: 100%;
       margin: 10px;
-      fill: var(--primary-text-color);
     }
 
     .grid-item-album-image.playing {
@@ -844,9 +839,6 @@ export class SpotifyCard extends LitElement {
     .grid-item-overlay-icon:hover {
       transform: scale(2);
       opacity: 1;
-    }
-    .grid-item-overlay-icon > svg {
-      fill: white;
     }
   `;
 }

--- a/src/spotify-card.ts
+++ b/src/spotify-card.ts
@@ -772,6 +772,7 @@ export class SpotifyCard extends LitElement {
 
     .cover > img {
       height: 100%;
+      max-width: var(--list-item-height); /* enforce square playlist icons */
     }
 
     .cover > svg {

--- a/src/spotify-card.ts
+++ b/src/spotify-card.ts
@@ -641,7 +641,7 @@ export class SpotifyCard extends LitElement {
     }
 
     .small-icon svg {
-      height: 3em;
+      height: 2em;
     }
 
     .controls {

--- a/src/spotify-card.ts
+++ b/src/spotify-card.ts
@@ -617,7 +617,7 @@ export class SpotifyCard extends LitElement {
       align-items: center;
       justify-content: space-between;
       height: var(--footer-height);
-      margin-top: 0.5em;
+      padding: 0.5rem;
     }
 
     .footer__right {
@@ -645,7 +645,6 @@ export class SpotifyCard extends LitElement {
     }
 
     .controls {
-      padding: 0.5em;
       display: flex;
     }
 


### PR DESCRIPTION
Hi again! 

You all were so open to my initial issue that I thought I'd help out a bit how I can.
There're a few changes in here, which we can all discuss independently. 

1) fix up some padding/margin applications to be more universal so we don't worry about applying margin/padding to footer sub elements
2) Use more generic selectors for coloring svgs. 
3) Specify a fixed width for covers in the list view. 
This fixes some user-created playlists to not stand out so much, at the cost of the provided image getting warped.
4) Make the Spotify logo slightly smaller

Feel free to merge any/all of these changes.
I didn't commit any of the files from `dist/` (so that we could release these commits piecemeal),
so that still needs to be done before another release.

Hope you like some of the changes, small as they are!