### PR TITLE
Debug spotify state

### DIFF
--- a/src/spotcast-connector.ts
+++ b/src/spotcast-connector.ts
@@ -48,7 +48,7 @@ export class SpotcastConnector implements ISpotcastConnector {
   }
 
   public is_loaded(): boolean {
-    if (this.parent.playlists.length !== undefined) {
+    if (this.parent.playlists.length !== 0) {
       return true;
     }
     return false;

--- a/src/spotify-card.ts
+++ b/src/spotify-card.ts
@@ -85,10 +85,10 @@ export class SpotifyCard extends LitElement {
   @property({ hasChanged: hasChangedCustom })
   public playlists: Array<Playlist> = [];
 
-  @property({ hasChanged: hasChangedCustom })
+  //@property({ hasChanged: hasChangedCustom })
   public devices: Array<ConnectDevice> = [];
 
-  @property({ hasChanged: hasChangedCustom })
+  //@property({ hasChanged: hasChangedCustom })
   public chromecast_devices: Array<ChromecastDevice> = [];
 
   @property({ hasChanged: hasChangedCustom })
@@ -385,6 +385,7 @@ export class SpotifyCard extends LitElement {
   }
 
   protected render(): TemplateResult | void {
+    console.log("render with:", this._spotify_state);
     let warning = html``;
     if (!this.isSpotcastInstalled()) {
       warning = this.showWarning(localize('common.show_missing_spotcast'));


### PR DESCRIPTION
I've found that sometimes the card is rendered without the spotify_state set. This causes missing playback information.
With this changes you can try to reproduce this error. 

This error occurs when you add a horizontal stack with 2 spotify-cards to lovelace.  In my local testing environment this is not happening, only on my normal HA instance. Can you please confirm if this error is also there for you?